### PR TITLE
Address permissions error when committing format changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" && \
 
 COPY entrypoint.sh /entrypoint.sh
 
+USER 1001:121
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,12 @@ inputs:
   style:
     description: 'style passed to clang-format. reads .clang-format file in the repo by default. see clang-format docs for more.'
     default: 'file'
+  base:
+    description: 'The base branch/commit to base the formatting off of'
+    default: 'HEAD^'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.style }}
+    - ${{ inputs.base }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 # Address fatal error with directory being owned by root
-git config --global --add safe.directory /github/workspace
+#git config --global --add safe.directory /github/workspace
 
 git-clang-format --style="$1" "$2"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/sh -l
 
-git-clang-format --style="$1" HEAD^
+# Address fatal error with directory being owned by root
+git config --global --add safe.directory /github/workspace
+
+git-clang-format --style="$1" "$2"
+
+ls -la .git/objects

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,3 @@
 #!/bin/sh -l
 
-# Address fatal error with directory being owned by root
-#git config --global --add safe.directory /github/workspace
-
 git-clang-format --style="$1" "$2"
-
-ls -la .git/objects


### PR DESCRIPTION
I've run permissions trouble when committing the changes made after running the formatter. It turns out that the Docker user defaults to root, so the commit action isn't able to add the changes to the git repo. I've added a `USER` argument in the Dockerfile to assume UID 1001, GUID 121 (observed when running `ls -la .git/objects` after running the formatter) which has solved my permissions issue. The alternative is to `chown -R` the entire git repo, but this seemed more elegant to me. Note that the UID/GUID might be different for other users, so I'll need to look into automating this discovery somehow

I also added a parameter to format against a different base to HEAD^ (e.g. master) - I thought it useful when working with large PRs